### PR TITLE
Directory specification to run fetch_revision task

### DIFF
--- a/lib/capistrano/git_copy/tasks/deploy.cap
+++ b/lib/capistrano/git_copy/tasks/deploy.cap
@@ -48,7 +48,9 @@ namespace :git_copy do
   desc 'Determine the revision that will be deployed'
   task :set_current_revision do
     run_locally do
-      set :current_revision, git_copy_utility.fetch_revision
+      within git_copy_utility.repo_path do
+        set :current_revision, git_copy_utility.fetch_revision
+      end
     end
   end
 


### PR DESCRIPTION
I add the directory specification to run `fetch_revision` task.

Without this specification, it would execute the `git rev-list` command in the path that is not a cloned git repository.
